### PR TITLE
remove misleading unused variable from test matrix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ features = [ "test" ]
 
 [[tool.hatch.envs.hatch-test.matrix]]
 python = [ "3.10", "3.11", "3.12" ]
-features = [ "test" ]
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/scmorph/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ optional-dependencies.doc = [
   "myst-nb>=1.1",
   "pandas",
   "scanpydoc>=0.14.1",
-  "scmorph",
   "sphinx>=4",
   "sphinx-autodoc-typehints",
   "sphinx-book-theme>=1",
@@ -57,7 +56,7 @@ optional-dependencies.doc = [
   "sphinxcontrib-bibtex>=1",
   "sphinxext-opengraph",
 ]
-optional-dependencies.test = [ "coverage", "pytest", "pytest-cov", "pytest-nunit", "scmorph" ]
+optional-dependencies.test = [ "coverage", "pytest", "pytest-cov", "pytest-nunit" ]
 # https://docs.pypi.org/project_metadata/#project-urls
 urls.Documentation = "https://scmorph.readthedocs.io/"
 urls.Homepage = "https://github.com/edbiomedai/scmorph"


### PR DESCRIPTION
See https://github.com/scverse/cookiecutter-scverse/issues/338

This block you re-added in d78d5dc6210b4215b6d307784411271dcbf80263 does what you want, the line removed in this PR does nothing.

```toml
[tool.hatch.envs.hatch-test]
features = [ "test" ]
```

Technically this block can also be removed

```toml
[[tool.hatch.envs.hatch-test.matrix]]
python = [ "3.10", "3.11", "3.12" ]
```

but it at least makes it so that a local `hatch test -a` doesn’t run for Python 3.13? If you want that?